### PR TITLE
Removing replaces in 1.1.0 csv

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.1.0/ibm-commonui-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.1.0/ibm-commonui-operator.v1.1.0.clusterserviceversion.yaml
@@ -359,5 +359,4 @@ spec:
     name: Erica Brown
   provider:
     name: IBM
-  replaces: ibm-commonui-operator.v0.0.0
   version: 1.1.0


### PR DESCRIPTION
Removing the replaces line from the 1.1.0 CSV for CICD to be able to create the operator catalog