### PR TITLE
make sa dynamic

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
@@ -102,7 +102,8 @@ metadata:
     certified: "false"
     containerImage: quay.io/opencloudio/ibm-commonui-operator:1.2.0
     createdAt: "2020-02-11T15:30:00Z"
-    description: The IBM Common Web UI delivers the common header api and Identity and access pages for common services.
+    description: The IBM Common Web UI delivers the common header api and Identity
+      and access pages for common services.
     repository: https://github.com/IBM/ibm-commonui-operator
     support: IBM
   name: ibm-commonui-operator.v1.2.0
@@ -233,7 +234,7 @@ spec:
           - patch
           - update
           - watch
-        serviceAccountName: default
+        serviceAccountName: ibm-commonui-operator
       deployments:
       - name: ibm-commonui-operator
         spec:
@@ -270,7 +271,7 @@ spec:
                 imagePullPolicy: Always
                 name: ibm-commonui-operator
                 resources: {}
-              serviceAccountName: default
+              serviceAccountName: ibm-commonui-operator
       permissions:
       - rules:
         - apiGroups:
@@ -354,7 +355,7 @@ spec:
           - patch
           - update
           - watch
-        serviceAccountName: default
+        serviceAccountName: ibm-commonui-operator
     strategy: deployment
   installModes:
   - supported: true

--- a/deploy/olm-catalog/ibm-commonui-operator/ibm-commonui-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/ibm-commonui-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
-- currentCSV: ibm-commonui-operator.v1.1.0
-  name: stable-v1
 - currentCSV: ibm-commonui-operator.v1.2.0
   name: dev
+- currentCSV: ibm-commonui-operator.v1.1.0
+  name: stable-v1
 defaultChannel: stable-v1
 packageName: ibm-commonui-operator-app

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
         productVersion: "3.3.0"
         productMetric: FREE
     spec:
-      serviceAccountName: default
+      serviceAccountName: ibm-commonui-operator
       containers:
         - name: ibm-commonui-operator
           # Replace this with the built image name

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ibm-commonui-operator
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: ibm-commonui-operator
 roleRef:
   kind: Role
   name: ibm-commonui-operator
@@ -16,7 +16,7 @@ metadata:
   name: ibm-commonui-operator
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: ibm-commonui-operator
   namespace: ibm-common-services
 roleRef:
   kind: ClusterRole

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ibm-commonui-operator

--- a/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
+++ b/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
@@ -350,6 +350,7 @@ func (r *ReconcileCommonWebUI) newDaemonSetForCR(instance *operatorsv1alpha1.Com
 					Annotations: Annotations,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: res.GetServiceAccountName(),
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/pkg/controller/legacyheaderservice/legacyheaderservice_controller.go
+++ b/pkg/controller/legacyheaderservice/legacyheaderservice_controller.go
@@ -330,6 +330,7 @@ func (r *ReconcileLegacyHeader) newDaemonSetForCR(instance *operatorsv1alpha1.Le
 					Annotations: Annotations,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: res.GetServiceAccountName(),
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -19,6 +19,8 @@ package resources
 import (
 	"encoding/json"
 
+	"os"
+
 	operatorsv1alpha1 "github.com/ibm/ibm-commonui-operator/pkg/apis/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1beta1"
@@ -859,4 +861,16 @@ func GetNavConfigContent() map[string]apiextv1beta.JSONSchemaProps {
 			},
 		}, // navitems
 	}
+}
+
+// returns the service account name or default if it is not set in the environment
+func GetServiceAccountName() string {
+
+	sa := "default"
+
+	envSa := os.Getenv("SA_NAME")
+	if len(envSa) > 0 {
+		sa = envSa
+	}
+	return sa
 }

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -19,8 +19,6 @@ package resources
 import (
 	"encoding/json"
 
-	"os"
-
 	operatorsv1alpha1 "github.com/ibm/ibm-commonui-operator/pkg/apis/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1beta1"
@@ -866,11 +864,6 @@ func GetNavConfigContent() map[string]apiextv1beta.JSONSchemaProps {
 // returns the service account name or default if it is not set in the environment
 func GetServiceAccountName() string {
 
-	sa := "default"
-
-	envSa := os.Getenv("SA_NAME")
-	if len(envSa) > 0 {
-		sa = envSa
-	}
+	sa := "ibm-commonui-operator"
 	return sa
 }


### PR DESCRIPTION
Tested, cluster/role bindings are tied to common ui sa and the resources are dynamically using the sa 
https://console-openshift-console.apps.primed.os.fyre.ibm.com
PrueP-Y4z2k-9sIM4-PmXJZ

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/36827