### PR TITLE
Adding bindinfo object to CSV

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
@@ -5,6 +5,24 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "odlm.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "name": "commonuibinding",
+            "namespace": "ibm-common-services"
+          },
+          "spec": {
+            "operand": "ibm-commonui-operator",
+            "registry": "common-service",
+            "description": "Binding information that should be accessible to commonui adopters",
+            "bindings": {
+              "public": {
+                "configmap": "common-web-ui-config"
+              }
+            }
+          }
+        },
+        {
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRequest",
           "metadata": {

--- a/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.2.0/ibm-commonui-operator.v1.2.0.clusterserviceversion.yaml
@@ -5,11 +5,10 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "odlm.ibm.com/v1alpha1",
+          "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandBindInfo",
           "metadata": {
-            "name": "commonuibinding",
-            "namespace": "ibm-common-services"
+            "name": "commonuibinding"
           },
           "spec": {
             "operand": "ibm-commonui-operator",


### PR DESCRIPTION
OperandBindInfo is being added to the CSV 
that will help expose our config maps and secrets to other services running in the cluster
This is for backward compatibility