### PR TITLE
update 1.3.1 operator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ REGISTRY_DEV ?= quay.io/ericabr
 CSV_VERSION ?= $(VERSION)
 NAMESPACE=ibm-common-services
 LEGACY_TAG ?= 3.2.5
-COMMON_TAG ?= 1.3.0
+COMMON_TAG ?= 1.3.1
 
 # Set the registry and tag for the operand/operator images
 OPERAND_REGISTRY ?= $(REGISTRY)

--- a/deploy/crds/operators.ibm.com_v1alpha1_commonwebui_cr.yaml
+++ b/deploy/crds/operators.ibm.com_v1alpha1_commonwebui_cr.yaml
@@ -30,7 +30,7 @@ spec:
     requestLimits: "300"
     requestMemory: "256"
     imageRegistry: quay.io/opencloudio
-    imageTag: 1.3.0
+    imageTag: 1.3.1
     serviceName: common-web-ui
-  operatorVersion: 1.3.0
-  version: 1.3.0
+  operatorVersion: 1.3.1
+  version: 1.3.1

--- a/deploy/olm-catalog/ibm-commonui-operator/1.3.1/ibm-commonui-operator.v1.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.3.1/ibm-commonui-operator.v1.3.1.clusterserviceversion.yaml
@@ -1,0 +1,459 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandRequest",
+          "metadata": {
+            "name": "ibm-commonui-request"
+          },
+          "spec": {
+            "requests": [
+              {
+                "operands": [
+                  {
+                    "name": "ibm-iam-operator"
+                  },
+                  {
+                    "name": "ibm-management-ingress-operator"
+                  },
+                  {
+                    "name": "ibm-platform-api-operator"
+                  },
+                  {
+                    "name": "ibm-cert-manager-operator"
+                  }
+                ],
+                "registry": "common-service"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "operators.ibm.com/v1alpha1",
+          "kind": "CommonWebUI",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "example-commonwebui",
+              "app.kubernetes.io/managed-by": "ibm-commonui-operator",
+              "app.kubernetes.io/name": "ibm-commonui-operator"
+            },
+            "name": "example-commonwebui"
+          },
+          "spec": {
+            "commonWebUIConfig": {
+              "cpuLimits": "300",
+              "cpuMemory": "256",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "1.3.1",
+              "ingressPath": "/common-nav",
+              "requestLimits": "300",
+              "requestMemory": "256",
+              "serviceName": "common-web-ui"
+            },
+            "globalUIConfig": {
+              "cloudPakVersion": "3.4.1",
+              "defaultAdminUser": "admin",
+              "defaultAuth": "",
+              "enterpriseLDAP": "",
+              "enterpriseSAML": "",
+              "osAuth": "",
+              "sessionPollingInterval": 5000
+            },
+            "operatorVersion": "1.3.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "300m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "300m",
+                "memory": "256Mi"
+              }
+            },
+            "version": "1.3.1"
+          }
+        },
+        {
+          "apiVersion": "operators.ibm.com/v1alpha1",
+          "kind": "SwitcherItem",
+          "metadata": {
+            "name": "example-switcheritem"
+          },
+          "spec": {
+            "cloudPakInfo": {
+              "display": "Cloud Pak Administration Hub",
+              "label": "administration-hub",
+              "landingPage": "/common-nav/dashboard",
+              "logoURL": ""
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Security
+    certified: "false"
+    containerImage: quay.io/opencloudio/ibm-commonui-operator@sha256:1cf87e27d306b56e1f376917aa874be5479a070d97782545bcab754c5ca1539f
+    description: The IBM Common Web UI delivers the common header API and the identity
+      and access pages for IBM Cloud Platform Common Services.
+    olm.skipRange: '>=1.1.0 <1.3.1'
+    repository: https://github.com/IBM/ibm-commonui-operator
+    support: IBM
+  name: ibm-commonui-operator.v1.3.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CommonWebUI is the Schema for the commonwebuis API
+      kind: CommonWebUI
+      name: commonwebuis.operators.ibm.com
+      version: v1alpha1
+      displayName: CommonWebUI service
+      resources:
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Ingress
+        name: ''
+        version: v1
+      - kind: Daemonset
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: LegacyHeader
+        name: ''
+        version: 'v1alpha1'
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: CommonWebUI
+        name: ''
+        version: 'v1alpha1'
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: Certificate
+        name: ''
+        version: v1alpha1
+      specDescriptors:
+        - description: Configuration parameters for common web ui specific to the service
+          displayName: Common Web UI Configuration
+          path: commonWebUIConfig
+        - description: Configuration parameters the service will consume particular to the cluster
+          displayName: Cluster configuration parameters
+          path: globalUIConfig
+        - description: Version for the installed operator
+          displayName: Operator Version 
+          path: operatorVersion
+      statusDescriptors:
+        - description: Displays names of pods associated with the Common Web UI service
+          displayName: Pod Names
+          path: nodes
+    - description: LegacyHeader is the Schema for the legacyHeader API
+      kind: LegacyHeader
+      name: legacyheaders.operators.ibm.com
+      version: v1alpha1
+      displayName: LegacyHeader service
+      resources:
+        - kind: Service
+          name: ''
+          version: v1
+        - kind: Ingress
+          name: ''
+          version: v1
+        - kind: Daemonset
+          name: ''
+          version: v1
+        - kind: Pod
+          name: ''
+          version: v1
+        - kind: ConfigMap
+          name: ''
+          version: v1
+        - kind: LegacyHeader
+          name: ''
+          version: 'v1alpha1'
+        - kind: ReplicaSet
+          name: ''
+          version: v1
+        - kind: CommonWebUI
+          name: ''
+          version: 'v1alpha1'
+        - kind: Deployment
+          name: ''
+          version: v1
+      specDescriptors:
+        - description: Configuration parameters for the legacy header service
+          displayName: Legacy header configuration parameters
+          path: legacyConfig
+        - description: Configuration parameters the service will consume particular to the cluster
+          displayName: Cluster configuration parameters
+          path: legacyGlobalUIConfig
+        - description: Version for the installed operator
+          displayName: Operator Version 
+          path: operatorVersion
+      statusDescriptors:
+        - description: Displays names of pods associated with the Legacy Header service
+          displayName: Pod Names
+          path: nodes
+    - description: SwitcherItem is the Schema for the switcheritems API
+      kind: SwitcherItem
+      name: switcheritems.operators.ibm.com
+      version: v1alpha1
+  description: "**Important:** Do not install this operator directly. Only install this operator using the IBM Common Services Operator. 
+  For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). 
+  Additionally, you can exit this panel and navigate to the IBM Common Services tile in OperatorHub to learn more about the operator.\n\n 
+  If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator 
+  service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).\n\n 
+  You can use the ibm-commonui-operator to install the Common Web UI service for the IBM Cloud Platform Common Services and access 
+  the Common Web UI console. You can use the Common Web UI console to access information and features from other IBM Cloud Platform 
+  Common Services or IBM Cloud Paks that you install. \n\nFor more information about the available IBM Cloud Platform Common Services, see
+   the [IBM Knowledge Center](http://ibm.biz/cpcsdocs). \n## Supported platforms \n\n Red Hat OpenShift Container Platform 4.2 or 
+   newer installed on one of the following platforms: \n\n- Linux x86_64 \n- Linux on Power (ppc64le) \n- Linux on IBM Z and 
+   LinuxONE \n## Prerequisites\n\n The Common Web UI service has dependencies on other IBM Cloud Platform Common Services. Before you install this operator, 
+   you need to first install the operator dependencies and prerequisites: \n For the list of operator dependencies, see the IBM Knowledge Center 
+   [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies). \n For the list of prerequisites for installing the operator, see the 
+   IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq). \n## Documentation \n\n To install the operator 
+   with the IBM Common Services Operator follow the the installation and configuration instructions within the IBM Knowledge Center. \n- If you are using the 
+   operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak, for a list of IBM Cloud Paks, see 
+   [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks). \n- If you are using the operator with an IBM Containerized Software, 
+   see the IBM Cloud Platform Common Services Knowledge Center [Installer documentation](http://ibm.biz/cpcs_opinstall)."
+  displayName: Ibm Commonui UI Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - clusterissuers
+          verbs:
+          - use
+        serviceAccountName: ibm-commonui-operator
+      deployments:
+      - name: ibm-commonui-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-commonui-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                openshift.io/scc: restricted
+                productID: 068a62892a1e4db39641342e592daa25
+                productMetric: FREE
+                productName: IBM Cloud Platform Common Services
+                productVersion: 3.4.0
+              labels:
+                app.kubernetes.io/instance: ibm-commonui-operator
+                app.kubernetes.io/managed-by: ibm-commonui-operator
+                app.kubernetes.io/name: ibm-commonui-operator
+                name: ibm-commonui-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: beta.kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
+              containers:
+              - command:
+                - ibm-commonui-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-commonui-operator
+                - name: COMMON_WEB_UI_IMAGE_TAG_OR_SHA
+                  value: sha256:b89c86bf9394f8ec493672a70b7b48e3ba96b64c4112a3b6b0915cd863cfe37b
+                - name: LEGACYHEADER_IMAGE_TAG_OR_SHA
+                  value: sha256:5c785b6c4dc2b53af8e0219415388e4bafcfce354c13c6ff62912a9e7c3abb46
+                image: quay.io/opencloudio/ibm-commonui-operator@sha256:1cf87e27d306b56e1f376917aa874be5479a070d97782545bcab754c5ca1539f
+                imagePullPolicy: Always
+                name: ibm-commonui-operator
+                resources:
+                  limits:
+                    cpu: 40m
+                    memory: 150Mi
+                  requests:
+                    cpu: 10m
+                    memory: 25Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+              serviceAccountName: ibm-commonui-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - common-webui
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - '*'
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.ibm.com
+          resources:
+          - commonwebuis
+          - legacyheaders
+          - commonwebuis/finalizers
+          - legacyheaders/finalizers
+          - legacyheaders/status
+          - commonwebuis/status
+          - switcheritems
+          - switcheritems/finalizers
+          - switcheritems/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - foundation.ibm.com
+          resources:
+          - navconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - '*'
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ibm-commonui-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - IBM
+  - Cloud
+  - Web Console
+  - Common Services
+  labels:
+    name: ibm-commonui-operator
+  links:
+  - name: GitHub
+    url: https://github.com/IBM/ibm-commonui-operator
+  maintainers:
+  - email: ericabr@us.ibm.com
+    name: Erica Brown
+  maturity: alpha
+  provider:
+    name: IBMa
+  replaces: ibm-commonui-operator.v1.3.0
+  version: 1.3.1

--- a/deploy/olm-catalog/ibm-commonui-operator/1.3.1/ibm-commonui-operator.v1.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.3.1/ibm-commonui-operator.v1.3.1.clusterserviceversion.yaml
@@ -446,6 +446,10 @@ spec:
   - Common Services
   labels:
     name: ibm-commonui-operator
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported 
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported 
   links:
   - name: GitHub
     url: https://github.com/IBM/ibm-commonui-operator

--- a/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_commonwebuis_crd.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_commonwebuis_crd.yaml
@@ -1,0 +1,116 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: commonwebuis.operators.ibm.com
+spec:
+  group: operators.ibm.com
+  names:
+    kind: CommonWebUI
+    listKind: CommonWebUIList
+    plural: commonwebuis
+    singular: commonwebui
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CommonWebUI is the Schema for the commonwebuis API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CommonWebUISpec defines the desired state of CommonWebUISpec
+          properties:
+            commonWebUIConfig:
+              description: CommonWebUIConfig defines the desired state of CommonWebUIConfig
+              properties:
+                cpuLimits:
+                  type: string
+                cpuMemory:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                ingressPath:
+                  type: string
+                requestLimits:
+                  type: string
+                requestMemory:
+                  type: string
+                serviceName:
+                  type: string
+              type: object
+            globalUIConfig:
+              description: GlobalUIConfig defines the desired state of GlobalUIConfig
+              properties:
+                cloudPakVersion:
+                  type: string
+                defaultAdminUser:
+                  type: string
+                defaultAuth:
+                  type: string
+                enterpriseLDAP:
+                  type: string
+                enterpriseSAML:
+                  type: string
+                osAuth:
+                  type: string
+                pullSecret:
+                  type: string
+                sessionPollingInterval:
+                  format: int32
+                  type: integer
+              type: object
+            operatorVersion:
+              type: string
+            replicas:
+              format: int32
+              type: integer
+            resources:
+              properties:
+                limits:
+                  properties:
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                  type: object
+                requests:
+                  properties:
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                  type: object
+              type: object
+            version:
+              type: string
+          type: object
+        status:
+          description: CommonWebUIStatus defines the observed state of CommonWebUI
+          properties:
+            nodes:
+              description: PodNames will hold the names of the commonwebui's
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_legacyheaders_crd.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_legacyheaders_crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: legacyheaders.operators.ibm.com
+spec:
+  group: operators.ibm.com
+  names:
+    kind: LegacyHeader
+    listKind: LegacyHeaderList
+    plural: legacyheaders
+    singular: legacyheader
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LegacyHeader is the Schema for the legacyHeader API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LegacyHeaderSpec defines the desired state of LegacyHeaderSpec
+          properties:
+            legacyConfig:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              properties:
+                cpuLimits:
+                  type: string
+                cpuMemory:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                ingressPath:
+                  type: string
+                legacyDocURL:
+                  type: string
+                legacyLogoAltText:
+                  type: string
+                legacyLogoHeight:
+                  type: string
+                legacyLogoPath:
+                  type: string
+                legacyLogoWidth:
+                  type: string
+                legacySupportURL:
+                  type: string
+                requestLimits:
+                  type: string
+                requestMemory:
+                  type: string
+                serviceName:
+                  type: string
+              type: object
+            legacyGlobalUIConfig:
+              description: LegacyGlobalUIConfig defines the desired state of LegacyGlobalUIConfig
+              properties:
+                cloudPakVersion:
+                  type: string
+                defaultAdminUser:
+                  type: string
+                pullSecret:
+                  type: string
+                sessionPollingInterval:
+                  format: int32
+                  type: integer
+              type: object
+            operatorVersion:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          description: LegacyHeaderStatus defines the observed state of LegacyHeaderService
+          properties:
+            nodes:
+              description: PodNames will hold the names of the legacyheader's
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_switcheritems_crd.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.3.1/operators.ibm.com_switcheritems_crd.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: switcheritems.operators.ibm.com
+spec:
+  group: operators.ibm.com
+  names:
+    kind: SwitcherItem
+    listKind: SwitcherItemList
+    plural: switcheritems
+    singular: switcheritem
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SwitcherItem is the Schema for the switcheritems API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SwitcherItemSpec defines the desired state of SwitcherItem
+          properties:
+            cloudPakInfo:
+              properties:
+                display:
+                  type: string
+                label:
+                  type: string
+                landingPage:
+                  type: string
+                logoURL:
+                  type: string
+              type: object
+            operatorVersion:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          description: SwitcherItemStatus defines the observed state of SwitcherItem
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@
 package version
 
 var (
-	Version = "1.3.0"
+	Version = "1.3.1"
 )


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/40713
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/40674
We will be using 1.3.0 shas for now, since 1.3.1 is not in quay