### PR TITLE
add permissions for extenstions api group

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.4.0/ibm-commonui-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.4.0/ibm-commonui-operator.v1.4.0.clusterserviceversion.yaml
@@ -569,6 +569,13 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
         serviceAccountName: ibm-commonui-operator
       deployments:
       - name: ibm-commonui-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -141,3 +141,10 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+  - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/42433

Logs (after adding cluster permissions to services and ingresses):
<img width="1390" alt="Screen Shot 2020-11-09 at 10 17 23 AM" src="https://user-images.githubusercontent.com/17713495/98559823-142ddc80-2275-11eb-80b6-78e77c1d8c66.png">

No more permissions required 