### PR TITLE
Added permissions for prometheus api

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.4.1/ibm-commonui-operator.v1.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.4.1/ibm-commonui-operator.v1.4.1.clusterserviceversion.yaml
@@ -583,6 +583,12 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
         serviceAccountName: ibm-commonui-operator
       deployments:
       - name: ibm-commonui-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -148,3 +148,9 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/42646

Network data for the dashboard was empty because our ClusterRole permissions needed to include the ability to get all namespaces for using the prometheus api. The data collector logs showed a parsing error before these permissions were added:

<img width="566" alt="Screen Shot 2020-11-18 at 8 37 52 AM" src="https://user-images.githubusercontent.com/35278268/99539004-b8053f80-297b-11eb-82b6-b0b99d6d36d3.png">

No errors are seen after adding the namespaces permission:

<img width="525" alt="Screen Shot 2020-11-18 at 8 56 16 AM" src="https://user-images.githubusercontent.com/35278268/99539211-f1d64600-297b-11eb-9fdf-0e637b9ea263.png">
