### PR TITLE
Added ClusterAdmin auth to Home page in NavConfig

### DIFF
--- a/deploy/crds/foundation.ibm.com_v1_navconfiguration_cr.yaml
+++ b/deploy/crds/foundation.ibm.com_v1_navconfiguration_cr.yaml
@@ -115,6 +115,8 @@ spec:
       label: "Home"
       url: "/common-nav/dashboard"
       iconUrl: "/common-nav/graphics/home.svg"
+      isAuthorized:
+        - "ClusterAdministrator"
     - id: "id-access"
       label: "Identity and Access"
       url: "/common-nav/identity-access"

--- a/deploy/olm-catalog/ibm-commonui-operator/1.4.1/ibm-commonui-operator.v1.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.4.1/ibm-commonui-operator.v1.4.1.clusterserviceversion.yaml
@@ -213,7 +213,10 @@ metadata:
                 "id": "home",
                 "label": "Home",
                 "url": "/common-nav/dashboard",
-                "iconUrl": "/common-nav/graphics/home.svg"
+                "iconUrl": "/common-nav/graphics/home.svg",
+                "isAuthorized": [
+                  "ClusterAdministrator"
+                ]
               },
               {
                 "id": "id-access",

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -309,7 +309,10 @@ var CrTemplates = `[
 			  "id": "home",
 			  "label": "Home",
 			  "url": "/common-nav/dashboard",
-			  "iconUrl": "/common-nav/graphics/home.svg"
+			  "iconUrl": "/common-nav/graphics/home.svg",
+				"isAuthorized": [
+					"ClusterAdministrator"
+			  ]
 			},
 			{
 			  "id": "id-access",


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/42873

`Home` page is now hidden in left nav for all roles other than `ClusterAdministrator`.

<img width="1680" alt="Screen Shot 2020-11-30 at 11 51 20 AM" src="https://user-images.githubusercontent.com/35278268/100638860-82107580-3302-11eb-9f81-e5ac4f7d2814.png">

<img width="1680" alt="Screen Shot 2020-11-30 at 11 53 00 AM" src="https://user-images.githubusercontent.com/35278268/100638979-9f454400-3302-11eb-8844-04692e87fc68.png">
