### PR TITLE
Addons extension

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	certmgr "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
+	routesv1 "github.com/openshift/api/route/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -134,6 +135,12 @@ func main() {
 
 	// Setup Scheme for cert-manager
 	if err := certmgr.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	//routes Scheme
+	if err := routesv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
@@ -6,6 +6,23 @@ metadata:
       [
         {
           "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "name": "ibm-commonui-bindinfo"
+          },
+          "spec": {
+            "operand": "ibm-commonui-operator",
+            "registry": "common-service",
+            "description": "Binding information that should be accessible to Zen AdminHub adopters",
+            "bindings": {
+              "public": {
+                "configmap": "common-webui-ui-extensions"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRequest",
           "metadata": {
             "name": "ibm-commonui-request"
@@ -385,14 +402,14 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Security
     certified: "false"
-    containerImage: quay.io/opencloudio/ibm-commonui-operator:1.5.0
+    containerImage: quay.io/ericabr/ibm-commonui-operator:1.5.0
     description: The IBM Common Web UI delivers the common header API and the identity
       and access pages for IBM Cloud Platform Common Services.
     olm.skipRange: '>=1.1.0 <1.5.0'
     repository: https://github.com/IBM/ibm-commonui-operator
     support: IBM
   name: ibm-commonui-operator.v1.5.0
-  namespace: placeholder
+  namespace: ibm-common-services
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -570,6 +587,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - apps
           resources:
@@ -646,7 +664,7 @@ spec:
                   value: sha256:5c785b6c4dc2b53af8e0219415388e4bafcfce354c13c6ff62912a9e7c3abb46
                 - name: DASHBOARD_DATA_COLL_IMAGE_TAG_OR_SHA
                   value: sha256:cd58bab5d6f4aebbcd17c02a8c935df0e71756e66bf74317269a8da9dec50de9
-                image: quay.io/opencloudio/ibm-commonui-operator:1.5.0
+                image: quay.io/ericabr/ibm-commonui-operator:1.5.0
                 imagePullPolicy: Always
                 name: ibm-commonui-operator
                 resources:

--- a/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
@@ -402,14 +402,14 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Security
     certified: "false"
-    containerImage: quay.io/ericabr/ibm-commonui-operator:1.5.0
+    containerImage: quay.io/opencloudio/ibm-commonui-operator:1.5.0
     description: The IBM Common Web UI delivers the common header API and the identity
       and access pages for IBM Cloud Platform Common Services.
     olm.skipRange: '>=1.1.0 <1.5.0'
     repository: https://github.com/IBM/ibm-commonui-operator
     support: IBM
   name: ibm-commonui-operator.v1.5.0
-  namespace: ibm-common-services
+  namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -664,7 +664,7 @@ spec:
                   value: sha256:5c785b6c4dc2b53af8e0219415388e4bafcfce354c13c6ff62912a9e7c3abb46
                 - name: DASHBOARD_DATA_COLL_IMAGE_TAG_OR_SHA
                   value: sha256:cd58bab5d6f4aebbcd17c02a8c935df0e71756e66bf74317269a8da9dec50de9
-                image: quay.io/ericabr/ibm-commonui-operator:1.5.0
+                image: quay.io/opencloudio/ibm-commonui-operator:1.5.0
                 imagePullPolicy: Always
                 name: ibm-commonui-operator
                 resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -132,6 +132,7 @@ rules:
   verbs:
     - get
     - list
+    - watch
 - apiGroups:
   - apps
   resources:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-openapi/spec v0.19.2
 	github.com/jetstack/cert-manager v0.10.1
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.13.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,7 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/opencontainers/runc v1.0.0-rc2.0.20190611121236-6cc515888830/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
+github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible h1:6il8W875Oq9vycPkRV5TteLP9IfMEX3lyOl5yN+CtdI=
 github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/generic-admission-server v1.14.0/go.mod h1:GD9KN/W4KxqRQGVMbqQHpHzb2XcQVvLCaBaSciqXvfM=

--- a/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
+++ b/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
@@ -18,9 +18,10 @@ package commonwebuiservice
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	res "github.com/ibm/ibm-commonui-operator/pkg/resources"
-
+	routesv1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	operatorsv1alpha1 "github.com/ibm/ibm-commonui-operator/pkg/apis/operators/v1alpha1"
@@ -180,7 +181,12 @@ func (r *ReconcileCommonWebUI) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 	// Check if the config maps already exist. If not, create a new one.
-	err = r.reconcileConfigMaps(instance, &needToRequeue)
+	err = r.reconcileConfigMaps(instance, res.Log4jsConfigMap, &needToRequeue)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = r.reconcileConfigMaps(instance, res.ExtensionsConfigMap, &needToRequeue)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -253,16 +259,35 @@ func (r *ReconcileCommonWebUI) Reconcile(request reconcile.Request) (reconcile.R
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileCommonWebUI) reconcileConfigMaps(instance *operatorsv1alpha1.CommonWebUI, needToRequeue *bool) error {
+func (r *ReconcileCommonWebUI) reconcileConfigMaps(instance *operatorsv1alpha1.CommonWebUI, nameOfCM string, needToRequeue *bool) error {
 	reqLogger := log.WithValues("func", "reconcileConfiMaps", "instance.Name", instance.Name)
 
 	reqLogger.Info("checking log4js config map Service")
 	// Check if the log4js config map already exists, if not create a new one
 	currentConfigMap := &corev1.ConfigMap{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: res.Log4jsConfigMap, Namespace: instance.Namespace}, currentConfigMap)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: nameOfCM, Namespace: instance.Namespace}, currentConfigMap)
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new ConfigMap
-		newConfigMap := res.Log4jsConfigMapUI(instance)
+		newConfigMap := &corev1.ConfigMap{}
+		if nameOfCM == res.Log4jsConfigMap {
+			newConfigMap = res.Log4jsConfigMapUI(instance)
+		} else if nameOfCM == res.ExtensionsConfigMap {
+			currentRoute := &routesv1.Route{}
+			//Get the cp-console route and add it to the configmap below
+			err2 := r.client.Get(context.TODO(), types.NamespacedName{Name: "cp-console", Namespace: instance.Namespace}, currentRoute)
+			if err2 != nil {
+				reqLogger.Error(err2, "Failed to get route for cp-console, try again later")
+			}
+			reqLogger.Info("Current route is: " + currentRoute.Spec.Host)
+
+			var ExtensionsData = map[string]string{
+				"add-ons.json": strings.Replace(addons, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
+				"extensions":   strings.Replace(extensions, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
+			}
+
+			newConfigMap = res.ExtensionsConfigMapUI(instance, ExtensionsData)
+
+		}
 
 		err = controllerutil.SetControllerReference(instance, newConfigMap, r.scheme)
 		if err != nil {
@@ -698,3 +723,50 @@ func (r *ReconcileCommonWebUI) deleteDaemonSet(instance *operatorsv1alpha1.Commo
 		reqLogger.Error(err, "Failed to get old DaemonSet")
 	}
 }
+
+var extensions = `
+[
+	{
+		"extension_point_id": "left_menu_item",
+		"extension_name": "dap-admin-hub",
+		"display_name": "Administration Hub",
+		"order_hint": 100,
+		"match_permissions": "administrator",
+		"meta": {},
+		"details": {
+			"parent_folder": "dap-header-administer",
+			"href": "/common-nav/dashboard",
+			"target": "adminhub"
+		}
+	}
+]`
+
+var addons = `
+			{
+			 "commonui":{
+					 "access_management_enable":false,
+					 "category":"zcs",
+					 "add_on_type":"application",
+					 "details":{
+						 "short_description":"IBM Administration Hub",
+						 "long_description":"This application delivers the IBM Administration Hub view for Cloud pak administrators.",
+						 "images":[
+								 "https://raw.githubusercontent.com/prashant182/res/master/g1.png",
+								 "https://raw.githubusercontent.com/prashant182/res/master/g2.png"
+						 ],
+						 "openURL":"/common-nav/dashboard",
+						 "external_open_url_target": "adminhub"
+					 },
+					 "display_name":"IBM Administration Hub",
+					 "extensions":{
+		
+					 },
+					 "max_instances":"1",
+					 "vendor":"IBM",
+					 "versions":{
+						 "3.5.0":{
+								 "state":"enabled"
+						 }
+					 }
+				 }
+			 }`

--- a/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
+++ b/pkg/controller/commonwebuiservice/commonwebuiservice_controller.go
@@ -281,8 +281,8 @@ func (r *ReconcileCommonWebUI) reconcileConfigMaps(instance *operatorsv1alpha1.C
 			reqLogger.Info("Current route is: " + currentRoute.Spec.Host)
 
 			var ExtensionsData = map[string]string{
-				"add-ons.json": strings.Replace(addons, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
-				"extensions":   strings.Replace(extensions, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
+				"add-ons.json": strings.Replace(res.Addons, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
+				"extensions":   strings.Replace(res.Extensions, "/common-nav/dashboard", "https://"+currentRoute.Spec.Host+"/common-nav/dashboard", 1),
 			}
 
 			newConfigMap = res.ExtensionsConfigMapUI(instance, ExtensionsData)
@@ -723,50 +723,3 @@ func (r *ReconcileCommonWebUI) deleteDaemonSet(instance *operatorsv1alpha1.Commo
 		reqLogger.Error(err, "Failed to get old DaemonSet")
 	}
 }
-
-var extensions = `
-[
-	{
-		"extension_point_id": "left_menu_item",
-		"extension_name": "dap-admin-hub",
-		"display_name": "Administration Hub",
-		"order_hint": 100,
-		"match_permissions": "administrator",
-		"meta": {},
-		"details": {
-			"parent_folder": "dap-header-administer",
-			"href": "/common-nav/dashboard",
-			"target": "adminhub"
-		}
-	}
-]`
-
-var addons = `
-			{
-			 "commonui":{
-					 "access_management_enable":false,
-					 "category":"zcs",
-					 "add_on_type":"application",
-					 "details":{
-						 "short_description":"IBM Administration Hub",
-						 "long_description":"This application delivers the IBM Administration Hub view for Cloud pak administrators.",
-						 "images":[
-								 "https://raw.githubusercontent.com/prashant182/res/master/g1.png",
-								 "https://raw.githubusercontent.com/prashant182/res/master/g2.png"
-						 ],
-						 "openURL":"/common-nav/dashboard",
-						 "external_open_url_target": "adminhub"
-					 },
-					 "display_name":"IBM Administration Hub",
-					 "extensions":{
-		
-					 },
-					 "max_instances":"1",
-					 "vendor":"IBM",
-					 "versions":{
-						 "3.5.0":{
-								 "state":"enabled"
-						 }
-					 }
-				 }
-			 }`

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -192,6 +192,53 @@ var UICertificateData = CertificateData{
 	Component: "common-web-ui",
 }
 
+var Extensions = `
+[
+	{
+		"extension_point_id": "left_menu_item",
+		"extension_name": "dap-admin-hub",
+		"display_name": "Administration Hub",
+		"order_hint": 100,
+		"match_permissions": "administrator",
+		"meta": {},
+		"details": {
+			"parent_folder": "dap-header-administer",
+			"href": "/common-nav/dashboard",
+			"target": "adminhub"
+		}
+	}
+]`
+
+var Addons = `
+{
+	"commonui":{
+			"access_management_enable":false,
+			"category":"zcs",
+			"add_on_type":"application",
+			"details":{
+				"short_description":"IBM Administration Hub",
+				"long_description":"This application delivers the IBM Administration Hub view for Cloud pak administrators.",
+				"images":[
+						"https://raw.githubusercontent.com/prashant182/res/master/g1.png",
+						"https://raw.githubusercontent.com/prashant182/res/master/g2.png"
+				],
+				"openURL":"/common-nav/dashboard",
+				"external_open_url_target": "adminhub"
+			},
+			"display_name":"IBM Administration Hub",
+			"extensions":{
+
+			},
+			"max_instances":"1",
+			"vendor":"IBM",
+			"versions":{
+				"3.5.0":{
+						"state":"enabled"
+				}
+			}
+		}
+	}`
+
 //nolint
 var CrTemplates = `[
 	{

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -46,6 +46,7 @@ type CertificateData struct {
 
 const ReleaseName = "common-web-ui"
 const Log4jsConfigMap = "common-web-ui-log4js"
+const ExtensionsConfigMap = "common-webui-ui-extensions"
 const CommonConfigMap = "common-web-ui-config"
 const DaemonSetName = "common-web-ui"
 const DeploymentName = "common-web-ui"
@@ -482,6 +483,22 @@ func LabelsForPodMetadata(deploymentName string, crType string, crName string) m
 		podLabels[key] = value
 	}
 	return podLabels
+}
+
+func ExtensionsConfigMapUI(instance *operatorsv1alpha1.CommonWebUI, data map[string]string) *corev1.ConfigMap {
+	reqLogger := log.WithValues("func", "ExtensionsConfigMapUI", "Name", instance.Name)
+	reqLogger.Info("CS??? Entry")
+	metaLabels := LabelsForMetadata(ExtensionsConfigMap)
+	metaLabels["icpdata_addon"] = "true"
+	configmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ExtensionsConfigMap,
+			Namespace: instance.Namespace,
+			Labels:    metaLabels,
+		},
+		Data: data,
+	}
+	return configmap
 }
 
 func Log4jsConfigMapUI(instance *operatorsv1alpha1.CommonWebUI) *corev1.ConfigMap {


### PR DESCRIPTION
This PR will do the following
- Add a new configmap that holds Zen extensions for our Addon and left hand menu item
- The configmap will have the FQDN url to our dashboard as a link 
- Adds a OPerandBindInfo to our alm_examples so it can be copied to other namespaces

If you install Zen in the current namespace, and common-web-ui is running there, Zen will have a link to our Admin hub
If you install Zen in another namespace, once the OperandBindInfo copies the configmap to the other namespace, Zen will have a link to our admin hub and the address is fully addressable
Picture of the Zen Nav bar
![image](https://user-images.githubusercontent.com/33731164/102406966-573c4780-3fb9-11eb-9c79-3813c1be2538.png)

Picture of the Admin Hub Addon
![image](https://user-images.githubusercontent.com/33731164/102407001-658a6380-3fb9-11eb-8435-33acf037edef.png)

PR for adding operandBindInfo https://github.com/IBM/ibm-common-service-operator/pull/332
This CAN be merged in any order you want.