### PR TITLE
Added role for getting must-gather jobs

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.5.0/ibm-commonui-operator.v1.5.0.clusterserviceversion.yaml
@@ -811,6 +811,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
         serviceAccountName: ibm-commonui-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -102,6 +102,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
To allow the dashboard to better track the progress of a must-gather request, the UI polls the status of the job created by the request. This is necessary because the `MustGatherJob` resource provided by the health check operator does not contain the status of the associated `Job` resource. The only way to be certain of a must-gather request's completion is by tracking this associated job.