### PR TITLE
Added check to preserve cert-manager added labels in EUS branch

### DIFF
--- a/pkg/resources/container.go
+++ b/pkg/resources/container.go
@@ -106,6 +106,7 @@ var ClusterCaVolume = corev1.Volume{
 // UI certificate definition
 const UICertName = "common-web-ui-ca-cert"
 const UICertCommonName = "common-web-ui"
+const certRestartLabel = "certmanager.k8s.io/time-restarted"
 
 // use concatenation so linter won't complain about "Secret" vars
 const UICertSecretName = "common-web-ui-cert" + ""

--- a/pkg/resources/reconcile.go
+++ b/pkg/resources/reconcile.go
@@ -60,6 +60,17 @@ func ReconcileDeployment(client client.Client, instanceNamespace string, deploym
 	} else {
 		// Found deployment, so determine if the resource has changed
 		logger.Info("Comparing Deployments")
+
+		// Preserve cert-manager added labels in metadata
+		if val, ok := currentDeployment.ObjectMeta.Labels[certRestartLabel]; ok {
+			newDeployment.ObjectMeta.Labels[certRestartLabel] = val
+		}
+
+		// Preserve cert-manager added labels in spec
+		if val, ok := currentDeployment.Spec.Template.ObjectMeta.Labels[certRestartLabel]; ok {
+			newDeployment.Spec.Template.ObjectMeta.Labels[certRestartLabel] = val
+		}
+
 		if !IsDeploymentEqual(currentDeployment, newDeployment) {
 			logger.Info("Updating Deployment", "Deployment.Name", currentDeployment.Name)
 			currentDeployment.ObjectMeta.Name = newDeployment.ObjectMeta.Name


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44253

Label preserved on deployment:
<img width="500" alt="Screen Shot 2021-02-02 at 3 19 54 PM" src="https://user-images.githubusercontent.com/35278268/106659501-d2a78780-656c-11eb-9619-1d9b6fad1992.png">

Label preserved on pod:
<img width="500" alt="Screen Shot 2021-02-02 at 3 19 35 PM" src="https://user-images.githubusercontent.com/35278268/106659500-d2a78780-656c-11eb-9844-666e9d43606a.png">
