### PR TITLE
Upgrade to the latest version of Go in EUS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ibm/ibm-commonui-operator
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-openapi/spec v0.19.2


### PR DESCRIPTION
Issue - https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44812

* Upgrade to the latest version of Go (1.14.14, 1.15.7 or later) for PSIRT