### PR TITLE
Network perm for promethues

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.4.2/ibm-commonui-operator.v1.4.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.4.2/ibm-commonui-operator.v1.4.2.clusterserviceversion.yaml
@@ -598,6 +598,12 @@ spec:
           - get
           - list
           - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
         serviceAccountName: ibm-commonui-operator
       deployments:
       - name: ibm-commonui-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -170,3 +170,9 @@ rules:
     - get
     - list
     - create
+- apiGroups:
+  - ""
+  resources:
+    - namespaces
+  verbs:
+    - get


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45971

In CS 3.6, the permissions needed for the network data in the adminhub were removed. Hence the network information was not available. 

![image (8)](https://user-images.githubusercontent.com/17713495/113931573-a0aadf80-97c0-11eb-9e2a-211048601149.png)

Adding permissions back via this pr resolves the issue:

![Screen Shot 2021-04-07 at 4 40 01 PM](https://user-images.githubusercontent.com/17713495/113931638-b4eedc80-97c0-11eb-8d1c-236802b25550.png)
