### PR TITLE
put quick nav definitions in own configmap to workaround customizatio…

### DIFF
--- a/pkg/controller/commonwebuizen/commonwebuizen_controller.go
+++ b/pkg/controller/commonwebuizen/commonwebuizen_controller.go
@@ -199,6 +199,10 @@ func (r *ReconcileCommonWebUIZen) Reconcile(ctx context.Context, request reconci
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		err = r.reconcileConfigMapsZen(ctx, namespace, res.ZenQuickNavExtensionsConfigMap)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = r.reconcileCrZen(ctx, namespace, "admin-hub-zen", res.CrTemplates2, isZen)
 		if err != nil {
 			reqLogger.Error(err, "Error creating console link cr for zen")
@@ -285,7 +289,13 @@ func (r *ReconcileCommonWebUIZen) reconcileConfigMapsZen(ctx context.Context, na
 				"nginx.conf": res.ZenNginxConfig,
 				"extensions": res.ZenCardExtensions,
 			}
-			newConfigMap = res.ZenCardExtensionsConfigMapUI(namespace, version.Version, ExtensionsData)
+			newConfigMap = res.ZenCardExtensionsConfigMapUI(res.ZenCardExtensionsConfigMap, namespace, version.Version, ExtensionsData)
+		} else if nameOfCM == res.ZenQuickNavExtensionsConfigMap {
+			reqLogger.Info("Creating zen quick nav extensions config map")
+			var ExtensionsData = map[string]string{
+				"extensions": res.ZenQuickNavExtensions,
+			}
+			newConfigMap = res.ZenCardExtensionsConfigMapUI(res.ZenQuickNavExtensionsConfigMap, namespace, version.Version, ExtensionsData)
 		} else if nameOfCM == res.CommonConfigMap {
 			reqLogger.Info("Creating common-web-ui-config config map")
 			newConfigMap = res.CommonWebUIConfigMap(namespace)

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -46,6 +46,7 @@ const ReleaseName = "common-web-ui"
 const Log4jsConfigMap = "common-web-ui-log4js"
 const ExtensionsConfigMap = "common-webui-ui-extensions"
 const ZenCardExtensionsConfigMap = "common-web-ui-zen-card-extensions"
+const ZenQuickNavExtensionsConfigMap = "common-web-ui-zen-quicknav-extensions"
 const CommonConfigMap = "common-web-ui-config"
 const DaemonSetName = "common-web-ui"
 const DeploymentName = "common-web-ui"
@@ -220,6 +221,31 @@ var ZenNginxConfig = `
 				proxy_read_timeout 10m;
 		}
 `
+
+var ZenQuickNavExtensions = `
+[
+      {
+        "extension_point_id": "homepage_quick_navigation",
+        "extension_name": "homepage_quick_navigation_id_providers",
+        "display_name": "{{ .global_zen_homepage_nav_id_providers }}",
+        "order_hint": 100,
+        "match_permissions": "administrator",
+        "match_instance_id": "",
+        "match_instance_role": "",
+        "meta": {
+          "extension_type": "ootb",
+          "reference": {
+            "nav_item": "nav-id-providers"
+          }
+        },
+        "details": {
+          "label": "{{ .global_adminhub_id_providers }}",
+          "nav_link": "/common-nav/zen/idproviders"
+        }
+      }
+]
+`
+
 var ZenCardExtensions = `
 [
 	  {
@@ -232,19 +258,6 @@ var ZenCardExtensions = `
         "details": {
 			"parent_folder": "dap-header-administer",
 			"href": "/common-nav/zen/idproviders"
-        }
-      },
-      {
-        "extension_point_id": "homepage_quick_navigation",
-        "extension_name": "homepage_quick_navigation_id_providers",
-        "display_name": "{{ .global_zen_homepage_nav_id_providers }}",
-        "order_hint": 100,
-        "match_permissions": "administrator",
-        "match_instance_id": "",
-        "match_instance_role": "",
-        "details": {
-          "label": "{{ .global_adminhub_id_providers }}",
-          "nav_link": "/common-nav/zen/idproviders"
         }
       },
       {
@@ -883,7 +896,7 @@ func ExtensionsConfigMapUI(namespace string, data map[string]string) *corev1.Con
 	return configmap
 }
 
-func ZenCardExtensionsConfigMapUI(namespace string, version string, data map[string]string) *corev1.ConfigMap {
+func ZenCardExtensionsConfigMapUI(name string, namespace string, version string, data map[string]string) *corev1.ConfigMap {
 	reqLogger := log.WithValues("func", "ExtensionsConfigMapUI")
 	reqLogger.Info("CS??? Entry")
 	metaLabels := LabelsForMetadata(ExtensionsConfigMap)
@@ -891,7 +904,7 @@ func ZenCardExtensionsConfigMapUI(namespace string, version string, data map[str
 	metaLabels["icpdata_addon_version"] = "v" + version
 	configmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ZenCardExtensionsConfigMap,
+			Name:      name,
 			Namespace: namespace,
 			Labels:    metaLabels,
 		},


### PR DESCRIPTION
break quicknav definitions into separate configmap to workaround customization selection of nav link and quick nav for manage identity providers.
![image](https://user-images.githubusercontent.com/20325236/135553351-7f7bb466-d99d-4962-9a13-4361133d9722.png)
