### PR TITLE
Removed CSP header from ingresses

### DIFF
--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -121,7 +121,6 @@ var APIIngressAnnotations = map[string]string{
 	//nolint
 	"icp.management.ibm.com/configuration-snippet": `
 		add_header 'X-XSS-Protection' '1' always;
-        add_header Content-Security-Policy "default-src 'none'; font-src 'unsafe-inline' 'self'; script-src 'unsafe-inline' 'self' blob: cdn.segment.com fast.appcues.com; connect-src 'self' https://api.segment.io wss://api.appcues.net https://notify.bugsnag.com; img-src * data:; frame-src 'self' https://my.appcues.com; style-src 'unsafe-inline' 'self' https://fast.appcues.com; frame-ancestors 'self'";
         port_in_redirect off;`,
 }
 
@@ -138,8 +137,7 @@ var CommonUIIngressAnnotations = map[string]string{
 	"icp.management.ibm.com/app-root":        "/common-nav?root=true",
 	//nolint
 	"icp.management.ibm.com/configuration-snippet": `
-		add_header 'X-XSS-Protection' '1' always;
-        add_header Content-Security-Policy "default-src 'none'; font-src * 'unsafe-inline' 'self' data:; script-src 'unsafe-inline' 'self' blob: cdn.segment.com fast.appcues.com; connect-src 'self' https://api.segment.io wss://api.appcues.net https://notify.bugsnag.com; img-src * data:; frame-src 'self' https://my.appcues.com; style-src 'unsafe-inline' 'self' https://fast.appcues.com; frame-ancestors 'self' https://*.multicloud-ibm.com";`,
+		add_header 'X-XSS-Protection' '1' always;`,
 }
 
 var CommonLegacyIngressAnnotations = map[string]string{


### PR DESCRIPTION
https://github.ibm.com/ibmprivatecloud/roadmap/issues/50475

Common UI ingresses currently overwrite Content-Security-Policy headers set by our server. This PR removes the CSP header from the common-nav and api ingresses, so that our server can dynamically generate nonce values for inline scripts and styles.