### PR TITLE
Add permission for licensing new auth method

### DIFF
--- a/deploy/olm-catalog/ibm-commonui-operator/1.13.0/ibm-commonui-operator.v1.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-commonui-operator/1.13.0/ibm-commonui-operator.v1.13.0.clusterserviceversion.yaml
@@ -667,6 +667,11 @@ spec:
           - get
           - list
           - create
+        - nonResourceURLs:
+          - /products
+          - /health
+          verbs:
+          - get
         serviceAccountName: ibm-commonui-operator
       deployments:
       - name: ibm-commonui-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -238,3 +238,8 @@ rules:
     - get
     - list
     - create
+- nonResourceURLs:
+    - /products
+    - /health
+  verbs:
+    - get


### PR DESCRIPTION
This change adds permission for the ibm-commonui-operator Service Account that allows connecting with Licensing API using the new auth method. 
No more changes are required as UI requests already contain required headers.