### PR TITLE
CPD-Quality 57014, add default labels to cluster scoped resources

### DIFF
--- a/helm-cluster-scoped/templates/00-operators.ibm.com_commonwebuis.yaml
+++ b/helm-cluster-scoped/templates/00-operators.ibm.com_commonwebuis.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/instance: ibm-commonui-operator
     app.kubernetes.io/managed-by: ibm-commonui-operator
     app.kubernetes.io/name: commonwebuis.operators.ibm.com
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operators.ibm.com
   names:

--- a/helm-cluster-scoped/templates/01-foundation.ibm.com_navconfigurations.yaml
+++ b/helm-cluster-scoped/templates/01-foundation.ibm.com_navconfigurations.yaml
@@ -7,6 +7,12 @@ metadata:
     app.kubernetes.io/instance: ibm-commonui-operator
     app.kubernetes.io/managed-by: ibm-commonui-operator
     app.kubernetes.io/name: navconfigurations.foundation.ibm.com
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: foundation.ibm.com
   names:

--- a/helm-cluster-scoped/templates/02-operators.ibm.com_switcheritems.yaml
+++ b/helm-cluster-scoped/templates/02-operators.ibm.com_switcheritems.yaml
@@ -10,6 +10,12 @@ metadata:
     app.kubernetes.io/instance: ibm-commonui-operator
     app.kubernetes.io/managed-by: ibm-commonui-operator
     app.kubernetes.io/name: switcheritems.operators.ibm.com
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operators.ibm.com
   names:


### PR DESCRIPTION
What this PR does / why we need it: CPD BR team requires cluster scoped resources to have both addOnID and tenant operator namespace defined in all cluster resources so they can be appropriately tracked and backed up. Enabling these values allows for flexibly setting both common labels for namespace scoped and cluster scoped resources and cluster specific labels.

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/57014